### PR TITLE
Added logic to check for existing usernames/emails

### DIFF
--- a/art_vault/artvault/src/app/_components/Form/Signup/SignupForm.jsx
+++ b/art_vault/artvault/src/app/_components/Form/Signup/SignupForm.jsx
@@ -23,6 +23,8 @@ export default function SignupForm() {
                 password: form.password.value,
             }),
         });
+        
+        const responseData = await response.json();
 
         if(response.ok) {
             setIsLoading(false);
@@ -31,7 +33,7 @@ export default function SignupForm() {
             router.refresh();
         } else {
             setIsLoading(false);
-            setResponseError(response.error)
+            setResponseError(responseData.message)
         };
     };
 

--- a/art_vault/artvault/src/app/api/auth/register/route.js
+++ b/art_vault/artvault/src/app/api/auth/register/route.js
@@ -8,7 +8,25 @@ export async function POST(request){
         console.log({email, username, password})
 
         const hashedPassword = await hash(password, 10)
+        
+        const checkname = await prisma.user.findUnique({
+            where: {
+              username: username,
+            }
+        })
+        const checkemail = await prisma.user.findUnique({
+            where: {
+              email: email,
+            }
+        })
 
+        if (checkname) {
+            return NextResponse.json({ message: "Username Already Exists" }, { status: 400 });
+        };
+        if (checkemail) {
+            return NextResponse.json({ message: "Email Already Exists" }, { status: 400 });
+        };
+        
         const user = await prisma.user.create({
             data: {
               email: email,


### PR DESCRIPTION
Added logic to check if a username or email already exists when a user is registering for an account. If there is an existing name, an error is thrown on the signup page/modal