### PR TITLE
Updated eslintrc

### DIFF
--- a/art_vault/artvault/.eslintrc.json
+++ b/art_vault/artvault/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["next/babel","next/core-web-vitals", "prettier"]
+  "extends": ["next","next/core-web-vitals", "prettier"]
 }


### PR DESCRIPTION
changed extension of "next/babel" to "next" to fix linter error on build.